### PR TITLE
config maps and secrets follow pods

### DIFF
--- a/charts/multicluster-scheduler/templates/cr.yaml
+++ b/charts/multicluster-scheduler/templates/cr.yaml
@@ -54,6 +54,8 @@ rules:
       - get
       - list
       - watch
+      - configmaps
+      - secrets
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -102,6 +104,8 @@ rules:
       - ""
     resources:
       - services
+      - secrets
+      - configmaps
     verbs:
       - get
       - list

--- a/charts/multicluster-scheduler/templates/post-delete/cr.yaml
+++ b/charts/multicluster-scheduler/templates/post-delete/cr.yaml
@@ -13,6 +13,8 @@ rules:
     resources:
       - pods
       - services
+      - configmaps
+      - secrets
     verbs:
       - list
       - patch

--- a/pkg/controllers/chaperon/controller.go
+++ b/pkg/controllers/chaperon/controller.go
@@ -115,10 +115,7 @@ func (c *reconciler) Handle(obj interface{}) (requeueAfter *time.Duration, err e
 	// Convert the namespace/name string into a distinct namespace and name
 	key := obj.(string)
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("invalid resource key: %s", key))
-		return nil, nil
-	}
+	utilruntime.Must(err)
 
 	// Get the PodChaperon resource with this namespace/name
 	podChaperon, err := c.podChaperonsLister.PodChaperons(namespace).Get(name)

--- a/pkg/controllers/follow/cm.go
+++ b/pkg/controllers/follow/cm.go
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2020 The Multicluster-Scheduler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package follow
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	"admiralty.io/multicluster-controller/pkg/patterns"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"admiralty.io/multicluster-scheduler/pkg/common"
+	"admiralty.io/multicluster-scheduler/pkg/controller"
+	"admiralty.io/multicluster-scheduler/pkg/model/proxypod"
+)
+
+const proxyPodByConfigMaps = "proxyPodByConfigMaps"
+
+type configMapReconciler struct {
+	kubeclientset kubernetes.Interface
+	remoteClients map[string]kubernetes.Interface
+
+	podLister       corelisters.PodLister
+	configMapLister corelisters.ConfigMapLister
+
+	remoteConfigMapLister map[string]corelisters.ConfigMapLister
+
+	podIndex cache.Indexer
+
+	selfTargetName string
+}
+
+func NewConfigMapController(
+	kubeclientset kubernetes.Interface,
+	remoteClients map[string]kubernetes.Interface,
+
+	podInformer coreinformers.PodInformer,
+	configMapInformer coreinformers.ConfigMapInformer,
+
+	remoteConfigMapInformers map[string]coreinformers.ConfigMapInformer,
+
+	selfTargetName string) *controller.Controller {
+
+	r := &configMapReconciler{
+		kubeclientset: kubeclientset,
+		remoteClients: remoteClients,
+
+		podLister:       podInformer.Lister(),
+		configMapLister: configMapInformer.Lister(),
+
+		remoteConfigMapLister: make(map[string]corelisters.ConfigMapLister, len(remoteConfigMapInformers)),
+
+		podIndex: podInformer.Informer().GetIndexer(),
+
+		selfTargetName: selfTargetName,
+	}
+
+	informersSynced := make([]cache.InformerSynced, 2+len(remoteConfigMapInformers))
+	informersSynced[0] = podInformer.Informer().HasSynced
+	informersSynced[1] = configMapInformer.Informer().HasSynced
+
+	i := 2
+	for targetName, informer := range remoteConfigMapInformers {
+		r.remoteConfigMapLister[targetName] = informer.Lister()
+		informersSynced[i] = informer.Informer().HasSynced
+		i++
+	}
+
+	c := controller.New("config-maps-follow", r, informersSynced...)
+
+	configMapInformer.Informer().AddEventHandler(controller.HandleAddUpdateWith(c.EnqueueObject))
+
+	getConfigMap := func(namespace, name string) (metav1.Object, error) {
+		return r.configMapLister.ConfigMaps(namespace).Get(name)
+	}
+	for _, informer := range remoteConfigMapInformers {
+		informer.Informer().AddEventHandler(controller.HandleAllWith(c.EnqueueRemoteController("ConfigMap", getConfigMap)))
+	}
+
+	podInformer.Informer().AddEventHandler(controller.HandleAllWith(enqueueProxyPodsConfigMaps(c)))
+	podInformer.Informer().AddIndexers(map[string]cache.IndexFunc{
+		proxyPodByConfigMaps: indexProxyPodByConfigMaps,
+	})
+
+	return c
+}
+
+func enqueueProxyPodsConfigMaps(c *controller.Controller) func(obj interface{}) {
+	return func(obj interface{}) {
+		keys, _ := indexProxyPodByConfigMaps(obj)
+		for _, key := range keys {
+			c.EnqueueKey(key)
+		}
+	}
+}
+
+func indexProxyPodByConfigMaps(obj interface{}) ([]string, error) {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok || !proxypod.IsProxy(pod) {
+		return nil, nil
+	}
+	var keys []string
+	for _, vol := range pod.Spec.Volumes {
+		if cm := vol.ConfigMap; cm != nil {
+			keys = append(keys, fmt.Sprintf("%s/%s", pod.Namespace, cm.Name))
+		}
+		if proj := vol.Projected; proj != nil {
+			for _, src := range proj.Sources {
+				if cm := src.ConfigMap; cm != nil {
+					keys = append(keys, fmt.Sprintf("%s/%s", pod.Namespace, cm.Name))
+				}
+			}
+		}
+	}
+	for _, c := range pod.Spec.Containers {
+		keys = indexContainerByConfigMap(c, keys, pod)
+	}
+	for _, c := range pod.Spec.InitContainers {
+		keys = indexContainerByConfigMap(c, keys, pod)
+	}
+	return keys, nil
+}
+
+func indexContainerByConfigMap(c corev1.Container, keys []string, pod *corev1.Pod) []string {
+	for _, envVar := range c.Env {
+		if from := envVar.ValueFrom; from != nil {
+			if cm := from.ConfigMapKeyRef; cm != nil {
+				keys = append(keys, fmt.Sprintf("%s/%s", pod.Namespace, cm.Name))
+			}
+		}
+	}
+	for _, src := range c.EnvFrom {
+		if cm := src.ConfigMapRef; cm != nil {
+			keys = append(keys, fmt.Sprintf("%s/%s", pod.Namespace, cm.Name))
+		}
+	}
+	return keys
+}
+
+func (r configMapReconciler) Handle(obj interface{}) (requeueAfter *time.Duration, err error) {
+	key := obj.(string)
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	utilruntime.Must(err)
+
+	configMap, err := r.configMapLister.ConfigMaps(namespace).Get(name)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	terminating := configMap.DeletionTimestamp != nil
+
+	j := -1
+	for i, f := range configMap.Finalizers {
+		if f == common.CrossClusterGarbageCollectionFinalizer {
+			j = i
+			break
+		}
+	}
+	hasFinalizer := j > -1
+
+	objs, err := r.podIndex.ByIndex(proxyPodByConfigMaps, fmt.Sprintf("%s/%s", namespace, name))
+	utilruntime.Must(err)
+	targetNames := map[string]bool{}
+	for _, obj := range objs {
+		proxyPod := obj.(*corev1.Pod)
+		if proxypod.IsScheduled(proxyPod) {
+			if targetName := proxypod.GetScheduledClusterName(proxyPod); targetName != r.selfTargetName {
+				targetNames[targetName] = true
+			}
+		}
+	}
+
+	remoteConfigMaps := make(map[string]*corev1.ConfigMap)
+	for targetName := range targetNames {
+		var err error
+		remoteConfigMaps[targetName], err = r.remoteConfigMapLister[targetName].ConfigMaps(namespace).Get(name)
+		if !errors.IsNotFound(err) {
+			utilruntime.HandleError(err) // connection error with a target shouldn't block reconciliation with other targets
+		}
+	}
+
+	if terminating {
+		for targetName := range remoteConfigMaps {
+			if err := r.remoteClients[targetName].CoreV1().ConfigMaps(namespace).Delete(name, nil); err != nil && !errors.IsNotFound(err) {
+				return nil, err
+			}
+		}
+		if len(remoteConfigMaps) == 0 && hasFinalizer {
+			configMapCopy := configMap.DeepCopy()
+			configMapCopy.Finalizers = append(configMapCopy.Finalizers[:j], configMapCopy.Finalizers[j+1:]...)
+			var err error
+			if configMap, err = r.kubeclientset.CoreV1().ConfigMaps(namespace).Update(configMapCopy); err != nil {
+				if patterns.IsOptimisticLockError(err) {
+					d := time.Second
+					return &d, nil
+				} else {
+					return nil, err
+				}
+			}
+		}
+	} else if !hasFinalizer {
+		configMapCopy := configMap.DeepCopy()
+		configMapCopy.Finalizers = append(configMapCopy.Finalizers, common.CrossClusterGarbageCollectionFinalizer)
+		var err error
+		if configMap, err = r.kubeclientset.CoreV1().ConfigMaps(namespace).Update(configMapCopy); err != nil {
+			if patterns.IsOptimisticLockError(err) {
+				d := time.Second
+				return &d, nil
+			} else {
+				return nil, err
+			}
+		}
+	}
+
+	for targetName := range targetNames {
+		remoteConfigMap := remoteConfigMaps[targetName]
+		if remoteConfigMap == nil {
+			gold := makeRemoteConfigMap(configMap)
+			_, err := r.remoteClients[targetName].CoreV1().ConfigMaps(namespace).Create(gold)
+			if err != nil {
+				// error with a target shouldn't block reconciliation with other targets
+				d := time.Second
+				requeueAfter = &d // named returned
+				utilruntime.HandleError(err)
+			}
+		} else if !reflect.DeepEqual(remoteConfigMap.Data, configMap.Data) || !reflect.DeepEqual(remoteConfigMap.BinaryData, configMap.BinaryData) {
+			remoteConfigMapCopy := remoteConfigMap.DeepCopy()
+			remoteConfigMapCopy.Data = make(map[string]string, len(configMap.Data))
+			for k, v := range configMap.Data {
+				remoteConfigMapCopy.Data[k] = v
+			}
+			remoteConfigMapCopy.BinaryData = make(map[string][]byte, len(configMap.BinaryData))
+			for k, v := range configMap.BinaryData {
+				remoteConfigMapCopy.BinaryData[k] = make([]byte, len(v))
+				copy(remoteConfigMapCopy.BinaryData[k], v)
+			}
+			_, err := r.remoteClients[targetName].CoreV1().ConfigMaps(namespace).Update(remoteConfigMapCopy)
+			if err != nil {
+				// error with a target shouldn't block reconciliation with other targets
+				d := time.Second
+				requeueAfter = &d // named returned
+				utilruntime.HandleError(err)
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+func makeRemoteConfigMap(configMap *corev1.ConfigMap) *corev1.ConfigMap {
+	gold := &corev1.ConfigMap{}
+	gold.Name = configMap.Name
+	gold.Labels = make(map[string]string, len(configMap.Labels)+1)
+	gold.Labels[common.LabelKeyParentUID] = string(configMap.UID) // cross-cluster "owner reference"
+	for k, v := range configMap.Labels {
+		gold.Labels[k] = v
+	}
+	gold.Annotations = make(map[string]string, len(configMap.Annotations)+1)
+	for k, v := range configMap.Annotations {
+		gold.Annotations[k] = v
+	}
+	gold.Data = make(map[string]string, len(configMap.Data))
+	for k, v := range configMap.Data {
+		gold.Data[k] = v
+	}
+	gold.BinaryData = make(map[string][]byte, len(configMap.BinaryData))
+	for k, v := range configMap.BinaryData {
+		gold.BinaryData[k] = make([]byte, len(v))
+		copy(gold.BinaryData[k], v)
+	}
+	return gold
+}

--- a/pkg/controllers/follow/secret.go
+++ b/pkg/controllers/follow/secret.go
@@ -1,0 +1,298 @@
+/*
+ * Copyright 2020 The Multicluster-Scheduler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package follow
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	"admiralty.io/multicluster-controller/pkg/patterns"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"admiralty.io/multicluster-scheduler/pkg/common"
+	"admiralty.io/multicluster-scheduler/pkg/controller"
+	"admiralty.io/multicluster-scheduler/pkg/model/proxypod"
+)
+
+const proxyPodBySecrets = "proxyPodBySecrets"
+
+type secretReconciler struct {
+	kubeclientset kubernetes.Interface
+	remoteClients map[string]kubernetes.Interface
+
+	podLister    corelisters.PodLister
+	secretLister corelisters.SecretLister
+
+	remoteSecretLister map[string]corelisters.SecretLister
+
+	podIndex cache.Indexer
+
+	selfTargetName string
+}
+
+func NewSecretController(
+	kubeclientset kubernetes.Interface,
+	remoteClients map[string]kubernetes.Interface,
+
+	podInformer coreinformers.PodInformer,
+	secretInformer coreinformers.SecretInformer,
+
+	remoteSecretInformers map[string]coreinformers.SecretInformer,
+
+	selfTargetName string) *controller.Controller {
+
+	r := &secretReconciler{
+		kubeclientset: kubeclientset,
+		remoteClients: remoteClients,
+
+		podLister:    podInformer.Lister(),
+		secretLister: secretInformer.Lister(),
+
+		remoteSecretLister: make(map[string]corelisters.SecretLister, len(remoteSecretInformers)),
+
+		podIndex: podInformer.Informer().GetIndexer(),
+
+		selfTargetName: selfTargetName,
+	}
+
+	informersSynced := make([]cache.InformerSynced, 2+len(remoteSecretInformers))
+	informersSynced[0] = podInformer.Informer().HasSynced
+	informersSynced[1] = secretInformer.Informer().HasSynced
+
+	i := 2
+	for targetName, informer := range remoteSecretInformers {
+		r.remoteSecretLister[targetName] = informer.Lister()
+		informersSynced[i] = informer.Informer().HasSynced
+		i++
+	}
+
+	c := controller.New("secrets-follow", r, informersSynced...)
+
+	secretInformer.Informer().AddEventHandler(controller.HandleAddUpdateWith(c.EnqueueObject))
+
+	getSecret := func(namespace, name string) (metav1.Object, error) {
+		return r.secretLister.Secrets(namespace).Get(name)
+	}
+	for _, informer := range remoteSecretInformers {
+		informer.Informer().AddEventHandler(controller.HandleAllWith(c.EnqueueRemoteController("Secret", getSecret)))
+	}
+
+	podInformer.Informer().AddEventHandler(controller.HandleAllWith(enqueueProxyPodsSecrets(c)))
+	podInformer.Informer().AddIndexers(map[string]cache.IndexFunc{
+		proxyPodBySecrets: indexProxyPodBySecrets,
+	})
+
+	// TODO follow ingresses (TLS) when ingresses follows pods
+
+	return c
+}
+
+func enqueueProxyPodsSecrets(c *controller.Controller) func(obj interface{}) {
+	return func(obj interface{}) {
+		keys, _ := indexProxyPodBySecrets(obj)
+		for _, key := range keys {
+			c.EnqueueKey(key)
+		}
+	}
+}
+
+func indexProxyPodBySecrets(obj interface{}) ([]string, error) {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok || !proxypod.IsProxy(pod) {
+		return nil, nil
+	}
+	var keys []string
+	for _, vol := range pod.Spec.Volumes {
+		if s := vol.Secret; s != nil {
+			keys = append(keys, fmt.Sprintf("%s/%s", pod.Namespace, s.SecretName))
+		}
+		if proj := vol.Projected; proj != nil {
+			for _, src := range proj.Sources {
+				if s := src.Secret; s != nil {
+					keys = append(keys, fmt.Sprintf("%s/%s", pod.Namespace, s.Name))
+				}
+			}
+		}
+	}
+	for _, c := range pod.Spec.Containers {
+		keys = indexContainerBySecret(c, keys, pod)
+	}
+	for _, c := range pod.Spec.InitContainers {
+		keys = indexContainerBySecret(c, keys, pod)
+	}
+	for _, s := range pod.Spec.ImagePullSecrets {
+		keys = append(keys, fmt.Sprintf("%s/%s", pod.Namespace, s.Name))
+	}
+	return keys, nil
+}
+
+func indexContainerBySecret(c corev1.Container, keys []string, pod *corev1.Pod) []string {
+	for _, envVar := range c.Env {
+		if from := envVar.ValueFrom; from != nil {
+			if s := from.SecretKeyRef; s != nil {
+				keys = append(keys, fmt.Sprintf("%s/%s", pod.Namespace, s.Name))
+			}
+		}
+	}
+	for _, src := range c.EnvFrom {
+		if s := src.SecretRef; s != nil {
+			keys = append(keys, fmt.Sprintf("%s/%s", pod.Namespace, s.Name))
+		}
+	}
+	return keys
+}
+
+func (r secretReconciler) Handle(obj interface{}) (requeueAfter *time.Duration, err error) {
+	key := obj.(string)
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	utilruntime.Must(err)
+
+	secret, err := r.secretLister.Secrets(namespace).Get(name)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	terminating := secret.DeletionTimestamp != nil
+
+	j := -1
+	for i, f := range secret.Finalizers {
+		if f == common.CrossClusterGarbageCollectionFinalizer {
+			j = i
+			break
+		}
+	}
+	hasFinalizer := j > -1
+
+	objs, err := r.podIndex.ByIndex(proxyPodBySecrets, fmt.Sprintf("%s/%s", namespace, name))
+	utilruntime.Must(err)
+	targetNames := map[string]bool{}
+	for _, obj := range objs {
+		proxyPod := obj.(*corev1.Pod)
+		if proxypod.IsScheduled(proxyPod) {
+			if targetName := proxypod.GetScheduledClusterName(proxyPod); targetName != r.selfTargetName {
+				targetNames[targetName] = true
+			}
+		}
+	}
+
+	remoteSecrets := make(map[string]*corev1.Secret)
+	for targetName := range targetNames {
+		var err error
+		remoteSecrets[targetName], err = r.remoteSecretLister[targetName].Secrets(namespace).Get(name)
+		if !errors.IsNotFound(err) {
+			// error with a target shouldn't block reconciliation with other targets
+			d := time.Second
+			requeueAfter = &d // named returned
+			utilruntime.HandleError(err)
+		}
+	}
+
+	if terminating {
+		for targetName := range remoteSecrets {
+			if err := r.remoteClients[targetName].CoreV1().Secrets(namespace).Delete(name, nil); err != nil && !errors.IsNotFound(err) {
+				return nil, err
+			}
+		}
+		if len(remoteSecrets) == 0 && hasFinalizer {
+			secretCopy := secret.DeepCopy()
+			secretCopy.Finalizers = append(secretCopy.Finalizers[:j], secretCopy.Finalizers[j+1:]...)
+			var err error
+			if secret, err = r.kubeclientset.CoreV1().Secrets(namespace).Update(secretCopy); err != nil {
+				if patterns.IsOptimisticLockError(err) {
+					d := time.Second
+					return &d, nil
+				} else {
+					return nil, err
+				}
+			}
+		}
+	} else if !hasFinalizer {
+		secretCopy := secret.DeepCopy()
+		secretCopy.Finalizers = append(secretCopy.Finalizers, common.CrossClusterGarbageCollectionFinalizer)
+		var err error
+		if secret, err = r.kubeclientset.CoreV1().Secrets(namespace).Update(secretCopy); err != nil {
+			if patterns.IsOptimisticLockError(err) {
+				d := time.Second
+				return &d, nil
+			} else {
+				return nil, err
+			}
+		}
+	}
+
+	for targetName := range targetNames {
+		remoteSecret := remoteSecrets[targetName]
+		if remoteSecret == nil {
+			gold := makeRemoteSecret(secret)
+			_, err := r.remoteClients[targetName].CoreV1().Secrets(namespace).Create(gold)
+			if err != nil {
+				// error with a target shouldn't block reconciliation with other targets
+				d := time.Second
+				requeueAfter = &d // named returned
+				utilruntime.HandleError(err)
+			}
+		} else if !reflect.DeepEqual(remoteSecret.Data, secret.Data) {
+			remoteSecretCopy := remoteSecret.DeepCopy()
+			remoteSecretCopy.Data = make(map[string][]byte, len(secret.Data))
+			for k, v := range secret.Data {
+				remoteSecretCopy.Data[k] = make([]byte, len(v))
+				copy(remoteSecretCopy.Data[k], v)
+			}
+			_, err := r.remoteClients[targetName].CoreV1().Secrets(namespace).Update(remoteSecretCopy)
+			if err != nil {
+				// error with a target shouldn't block reconciliation with other targets
+				d := time.Second
+				requeueAfter = &d // named returned
+				utilruntime.HandleError(err)
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+func makeRemoteSecret(secret *corev1.Secret) *corev1.Secret {
+	gold := &corev1.Secret{}
+	gold.Name = secret.Name
+	gold.Labels = make(map[string]string, len(secret.Labels)+1)
+	gold.Labels[common.LabelKeyParentUID] = string(secret.UID) // cross-cluster "owner reference"
+	for k, v := range secret.Labels {
+		gold.Labels[k] = v
+	}
+	gold.Annotations = make(map[string]string, len(secret.Annotations))
+	for k, v := range secret.Annotations {
+		gold.Annotations[k] = v
+	}
+	gold.Type = secret.Type
+	gold.Data = make(map[string][]byte, len(secret.Data))
+	for k, v := range secret.Data {
+		gold.Data[k] = make([]byte, len(v))
+		copy(gold.Data[k], v)
+	}
+	return gold
+}

--- a/test/e2e/argo.sh
+++ b/test/e2e/argo.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 source test/e2e/aliases.sh
 source test/e2e/kind.sh
 
-ARGO_VERSION=2.4.3
+ARGO_VERSION=2.8.2
 ARGO_MANIFEST="https://raw.githubusercontent.com/argoproj/argo/v$ARGO_VERSION/manifests/install.yaml"
 ARGO_IMG="argoproj/argoexec:v$ARGO_VERSION"
 
@@ -67,3 +67,7 @@ argo_test() {
 
   KUBECONFIG=kubeconfig-cluster$i ./argo delete --all
 }
+
+if [[ "${BASH_SOURCE[0]:-}" == "${0}" ]]; then
+  argo_test "${@}"
+fi

--- a/test/e2e/e2e.sh
+++ b/test/e2e/e2e.sh
@@ -10,6 +10,7 @@ source test/e2e/cert-manager.sh
 source test/e2e/kind.sh
 source test/e2e/klum.sh
 source test/e2e/mcsa.sh
+source test/e2e/follow/test.sh
 
 argo_setup_once
 cert_manager_setup_once
@@ -29,5 +30,7 @@ argo_setup_source 1
 argo_setup_target 2
 #webhook_ready 1 admiralty multicluster-scheduler-controller-manager multicluster-scheduler multicluster-scheduler-cert
 argo_test 1 2
+
+follow_test 1 2
 
 echo "ALL SUCCEEDED"

--- a/test/e2e/follow/test.sh
+++ b/test/e2e/follow/test.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source test/e2e/aliases.sh
+
+follow_test() {
+  i=$1
+  j=$2
+
+  k $j label node --all a=b
+  k $i apply -f test/e2e/follow/test.yaml
+  k $i wait job/follow --for=condition=Complete
+  k $i delete -f test/e2e/follow/test.yaml
+  k $j label node --all a-
+}
+
+if [[ "${BASH_SOURCE[0]:-}" == "${0}" ]]; then
+  follow_test "${@}"
+fi

--- a/test/e2e/follow/test.yaml
+++ b/test/e2e/follow/test.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: follow
+data:
+  MY_CONFIG: foo
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: follow
+stringData:
+  MY_SECRET: bar
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: follow
+spec:
+  template:
+    metadata:
+      annotations:
+        multicluster.admiralty.io/elect: ""
+    spec:
+      nodeSelector:
+        a: b
+      restartPolicy: Never
+      containers:
+        - name: follow
+          image: busybox
+          command: ["/bin/sh", "-c", "[ $MY_CONFIG = foo ] && [ $MY_SECRET = bar ]"]
+          envFrom:
+            - configMapRef:
+                name: follow
+            - secretRef:
+                name: follow


### PR DESCRIPTION
If a proxy pod refers to config maps or secrets to be mounted as volumes, projected volumes, used as environment variables or, for secrets, as image pull secrets, Admiralty copies those config maps or secrets to the target cluster where the corresponding delegate pod runs.

fix #32

Signed-off-by: adrienjt <adrienjt@users.noreply.github.com>