### PR TITLE
remove unnecessary (sometimes confusing) logs

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -123,7 +123,6 @@ func (c *Controller) processNextWorkItem() bool {
 	// Finally, if no error occurs we Forget this item so it does not
 	// get queued again until another change happens.
 	c.workqueue.Forget(key)
-	klog.Infof("Successfully synced '%s'", key)
 	return true
 }
 

--- a/pkg/controllers/source/controller.go
+++ b/pkg/controllers/source/controller.go
@@ -33,7 +33,6 @@ import (
 	corelisters "k8s.io/client-go/listers/core/v1"
 	rbaclisters "k8s.io/client-go/listers/rbac/v1"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog"
 
 	multiclusterv1alpha1 "admiralty.io/multicluster-scheduler/pkg/apis/multicluster/v1alpha1"
 	"admiralty.io/multicluster-scheduler/pkg/controller"
@@ -82,8 +81,6 @@ func NewController(
 		roleBindingLister:        roleBindingInformer.Lister(),
 		clusterRoleBindingLister: clusterRoleBindingInformer.Lister(),
 	}
-
-	klog.Info("Setting up event handlers")
 
 	c := controller.New("source", r,
 		sourceInformer.Informer().HasSynced,

--- a/pkg/controllers/target/controller.go
+++ b/pkg/controllers/target/controller.go
@@ -26,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/klog"
 
 	"admiralty.io/multicluster-scheduler/pkg/controller"
 	informers "admiralty.io/multicluster-scheduler/pkg/generated/informers/externalversions/multicluster/v1alpha1"
@@ -55,8 +54,6 @@ func NewController(kubeClient kubernetes.Interface, installNamespace string, clu
 
 		installNamespace: installNamespace,
 	}
-
-	klog.Info("Setting up event handlers")
 
 	c := controller.New("source", r,
 		clusterTargetInformer.Informer().HasSynced,


### PR DESCRIPTION
the "successfully synced" message is especially confusing if nothing is synced, because, e.g., the key is filtered out when it's handled, rather than upstream in event handlers

Signed-off-by: adrienjt <adrienjt@users.noreply.github.com>